### PR TITLE
kinematic fix: Fix for unambiguous turning with cmd_vel.y velocity

### DIFF
--- a/robotino_simulation/worlds/webots_robotinobase1_sim.wbt
+++ b/robotino_simulation/worlds/webots_robotinobase1_sim.wbt
@@ -10,6 +10,15 @@ EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/project
 
 WorldInfo {
   basicTimeStep 32
+  contactProperties [
+    ContactProperties {
+      material1 "WheelMat"
+      coulombFriction [
+        0, 2, 0
+      ]
+      bounce 0
+    }
+  ]
 }
 Viewpoint {
   orientation 0.5847744123857989 0.44863110180843624 -0.6758468917654296 1.817859808388655

--- a/robotino_simulation/worlds/webots_robotinobase2_sim.wbt
+++ b/robotino_simulation/worlds/webots_robotinobase2_sim.wbt
@@ -10,6 +10,15 @@ EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/project
 
 WorldInfo {
   basicTimeStep 32
+  contactProperties [
+    ContactProperties {
+      material1 "WheelMat"
+      coulombFriction [
+        0, 2, 0
+      ]
+      bounce 0
+    }
+  ]
 }
 Viewpoint {
   orientation 0.4849642341009622 0.25032834227702466 -0.8379411749614073 1.8762916532305556

--- a/robotino_simulation/worlds/webots_robotinobase3_sim.wbt
+++ b/robotino_simulation/worlds/webots_robotinobase3_sim.wbt
@@ -10,6 +10,15 @@ EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/project
 
 WorldInfo {
   basicTimeStep 32
+  contactProperties [
+    ContactProperties {
+      material1 "WheelMat"
+      coulombFriction [
+        0, 2, 0
+      ]
+      bounce 0
+    }
+  ]
 }
 Viewpoint {
   orientation 0.5430283860834684 0.5505754804619956 -0.634024299393664 1.5829703860101791

--- a/robotino_simulation/worlds/webots_robotinocluster_sim.wbt
+++ b/robotino_simulation/worlds/webots_robotinocluster_sim.wbt
@@ -10,6 +10,15 @@ EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023b/project
 
 WorldInfo {
   basicTimeStep 32
+  contactProperties [
+    ContactProperties {
+      material1 "WheelMat"
+      coulombFriction [
+        0, 2, 0
+      ]
+      bounce 0
+    }
+  ]
 }
 Viewpoint {
   orientation 0.3050437976643899 0.12934232109895974 -0.9435140939483737 1.5119154023579888


### PR DESCRIPTION
Quick fix for unambiguous turning of the robot into after issuing velocity in y-direction.
1. Cross-checked all kinematic and inverse kinematic equations - all correct
2. Added contact properties with column friction for omni-wheels in webots world. 